### PR TITLE
Switch package license to Apache 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
      "polyfill"
   ],
   "author": "Cognitect",
-  "license": "APL",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/cognitect/npm-transit-js.git"


### PR DESCRIPTION
License is incorrectly marked as APL in package.json